### PR TITLE
Metrics: latency + token usage CSV logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 coverage/
 npm-debug.log*
 logs/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 .env.*.local
 coverage/
 npm-debug.log*
+logs/

--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ See `ROADMAP.md` for current status and decisions.
 - Prefers `Responses API` with `response_format: { type: "json_schema", strict: true }`.
 - Falls back to `chat.completions` with `response_format: { type: "json_object" }` if needed.
 - No external flight/hotel APIs yet; this is just a structured planning stub.
+
+## Metrics
+
+- Basic observability writes `logs/metrics.csv` with columns:
+  `timestamp,latency_ms,input_tokens,output_tokens,total_tokens,model,ok,error`.
+  Token fields are populated when available from the OpenAI API.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@
 - [ ] Persist last 10 queries (local JSON; later Firebase).
 - [ ] Deploy preview (Render/Fly/Heroku) + env management; server-only API key.
 - [ ] Add loading states, retry, copy-to-clipboard.
-- [ ] Token/latency logging (simple console/CSV).
+- [x] Token/latency logging (simple console/CSV).
 
 ## Later (Week 4–6)
 
@@ -44,3 +44,4 @@
  - 2025‑09‑07: Added formal tests (Vitest + Supertest) and updated npm scripts; retained optional offline smoke script.
  - 2025‑09‑07: Chose Render Web Service for deployment; added `render.yaml` blueprint with auto‑deploy on merges to `main`.
  - 2025‑09‑07: Enabled Render PR previews in `render.yaml` and added a "Deploy to Render" button in README for easy sharing.
+ - 2025‑09‑07: Added metrics logging (CSV) with latency and token usage.

--- a/tests/metrics.test.mjs
+++ b/tests/metrics.test.mjs
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+process.env.NODE_ENV = 'test';
+process.env.MOCK_OPENAI = '1';
+
+const { app } = await import('../server.js');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.join(__dirname, '..');
+const METRICS_FILE = path.join(ROOT, 'logs', 'metrics.csv');
+
+beforeEach(async () => {
+  try { await fs.rm(METRICS_FILE, { force: true }); } catch {}
+});
+
+describe('Metrics logging', () => {
+  it('appends a CSV row for a suggestion', async () => {
+    const res = await request(app)
+      .post('/suggest')
+      .send({ destination: 'Test City', start: '2025-10-01', end: '2025-10-02', travelers: 2, budgetUSD: 100 })
+      .set('Content-Type','application/json');
+    expect(res.status).toBe(200);
+
+    const csv = await fs.readFile(METRICS_FILE, 'utf8');
+    const lines = csv.trim().split(/\r?\n/);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(lines[0]).toContain('timestamp,latency_ms');
+  });
+});
+


### PR DESCRIPTION
Adds basic observability for the PoC.

Summary
- Log latency and token usage to `logs/metrics.csv`.
- CSV columns: `timestamp,latency_ms,input_tokens,output_tokens,total_tokens,model,ok,error`.
- Covers mock mode, Responses API path, chat fallback, and error cases.

Changes
- server.js: add `logMetrics()` and `extractUsage()`; instrument `/suggest`.
- tests/metrics.test.mjs: verifies a row is written.
- README: Metrics section.
- ROADMAP: check off logging item.
- .gitignore: ignore `logs/`.

Notes
- Filesystem on Render is ephemeral across deploys; sufficient for PoC.
- Future work: stream to durable storage (S3/Blob, etc.).

How to test
- `npm test` (includes metrics test).
- Run locally: hit `/suggest`, then check `logs/metrics.csv`.
