### PR TITLE
feat: infer request context for travel suggestions

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,53 @@
+import { Request } from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HISTORY_FILE = process.env.HISTORY_FILE || path.join(__dirname, '..', 'data', 'history.json');
+const DATA_DIR = path.dirname(HISTORY_FILE);
+
+export function inferGeolocation(req: Request): string | null {
+  return (req.headers['x-geo'] as string) || null;
+}
+
+export function inferLanguage(req: Request): string | null {
+  const lang = req.headers['accept-language'];
+  if (typeof lang !== 'string') return null;
+  return lang.split(',')[0] || null;
+}
+
+export async function readPastQueries(): Promise<any[]> {
+  try {
+    const raw = await fs.readFile(HISTORY_FILE, 'utf8');
+    const arr = JSON.parse(raw);
+    if (Array.isArray(arr)) {
+      return arr.map((e: any) => e.request || e);
+    }
+  } catch {}
+  return [];
+}
+
+export function inferDeviceHints(req: Request): string | null {
+  return (req.headers['user-agent'] as string) || null;
+}
+
+export async function collectContext(req: Request) {
+  const geo = inferGeolocation(req);
+  const language = inferLanguage(req);
+  const device = inferDeviceHints(req);
+  const pastQueries = await readPastQueries();
+  const last = pastQueries[pastQueries.length - 1] || {};
+  const defaults = {
+    destination: last.destination,
+    start: last.dates?.start,
+    end: last.dates?.end,
+    travelers: last.travelers,
+    budgetUSD: last.budgetUSD,
+  };
+  return { geo, language, device, pastQueries, defaults };
+}
+
+export type RequestContext = Awaited<ReturnType<typeof collectContext>>;
+

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.join(__dirname, '..');
+const DATA_DIR = path.join(ROOT, 'data');
+const HISTORY_FILE = path.join(DATA_DIR, 'history-context.json');
+
+process.env.HISTORY_FILE = HISTORY_FILE;
+process.env.NODE_ENV = 'test';
+process.env.MOCK_OPENAI = '1';
+
+const { app } = await import('../src/server.ts');
+
+async function resetHistory() {
+  try { await fs.rm(HISTORY_FILE, { force: true }); } catch {}
+}
+
+beforeEach(async () => { await resetHistory(); });
+
+describe('Context defaults', () => {
+  it('uses last travelers and budget when omitted', async () => {
+    const payload = { destination: 'City A', start: '2025-10-01', end: '2025-10-02', travelers: 3, budgetUSD: 500 };
+    const res1 = await request(app).post('/suggest').send(payload).set('Content-Type', 'application/json');
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app).post('/suggest')
+      .send({ destination: 'City B', start: '2025-11-01', end: '2025-11-02' })
+      .set('Content-Type', 'application/json');
+    expect(res2.status).toBe(200);
+    expect(res2.body.travelers).toBe(3);
+    expect(res2.body.budgetUSD).toBe(500);
+  });
+
+  it('defaults destination from last query', async () => {
+    const first = { destination: 'Tokyo', start: '2025-12-01', end: '2025-12-05', travelers: 1, budgetUSD: 800 };
+    const res1 = await request(app).post('/suggest').send(first).set('Content-Type', 'application/json');
+    expect(res1.status).toBe(200);
+
+    const res2 = await request(app).post('/suggest')
+      .send({ start: '2025-12-10', end: '2025-12-12', travelers: 2, budgetUSD: 600 })
+      .set('Content-Type', 'application/json');
+    expect(res2.status).toBe(200);
+    expect(res2.body.destination).toBe('Tokyo');
+  });
+});
+


### PR DESCRIPTION
## Summary
- collect geolocation, language, device hints and past queries via new `context` module
- default missing suggestion fields from prior history and store context alongside requests
- test context-based defaults for travelers, budget and destination

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beb3bda1f88331b6a0a96d3811d167