### PR TITLE
Expose cost breakdown in estimates

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -151,13 +151,13 @@
     };
     const fetchPgEstimate = async ()=>{
       const destination = pg.destination.value.trim();
-      if (!destination) { pg.estimate.textContent=''; return; }
+      if (!destination) { pg.estimate.innerHTML=''; return; }
       try {
         const r = await fetch(`/estimate?destination=${encodeURIComponent(destination)}&days=${pg.days.value}&travelers=${pg.travelers.value}`);
         const j = await r.json();
-        if (r.ok) pg.estimate.textContent = `Estimated total: $${j.minUSD}–$${j.maxUSD}`;
-      } catch { pg.estimate.textContent=''; }
-    };
+        if (r.ok) pg.estimate.innerHTML = `Estimated total: $${j.minUSD}–$${j.maxUSD}<ul><li>Flights: $${j.flightUSD}</li><li>Hotels: $${j.hotelUSD}</li></ul>`;
+      } catch { pg.estimate.innerHTML=''; }
+      };
     const onPgInput = ()=>{ updatePgOut(); fetchPgEstimate(); };
     pg.travelers.addEventListener('input', onPgInput);
     pg.days.addEventListener('input', onPgInput);
@@ -218,12 +218,12 @@
         const start = f.start.value;
         const end = f.end.value;
         const travelers = tInput.value;
-        if (!destination || !start || !end) { estOut.textContent=''; estOut.hidden=true; return; }
+        if (!destination || !start || !end) { estOut.innerHTML=''; estOut.hidden=true; return; }
         try {
           const r = await fetch(`/estimate?destination=${encodeURIComponent(destination)}&start=${start}&end=${end}&travelers=${travelers}`);
           const j = await r.json();
-          if (r.ok) { estOut.hidden=false; estOut.textContent = `Estimated total: $${j.minUSD}–$${j.maxUSD}`; }
-        } catch { estOut.textContent=''; estOut.hidden=true; }
+          if (r.ok) { estOut.hidden=false; estOut.innerHTML = `Estimated total: $${j.minUSD}–$${j.maxUSD}<ul><li>Flights: $${j.flightUSD}</li><li>Hotels: $${j.hotelUSD}</li></ul>`; }
+        } catch { estOut.innerHTML=''; estOut.hidden=true; }
       };
       const onSlider = ()=>{ updateSliderOut(); fetchEstimate(); };
       tInput.addEventListener('input', onSlider);

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -133,7 +133,15 @@ export function estimateCost(destination: string, travelers: number, days: numbe
   if (/paris|london|new york/.test(dest)) base = 200;
   else if (/bangkok|thailand|vietnam/.test(dest)) base = 50;
   const d = Math.max(Math.round(days), 1);
-  const total = base * d * Math.max(travelers, 1);
-  return { minUSD: Math.round(total * 0.8), maxUSD: Math.round(total * 1.2) };
+  const t = Math.max(travelers, 1);
+  const total = base * d * t;
+  const hotelUSD = Math.round(total * 0.6);
+  const flightUSD = Math.round(total - hotelUSD);
+  return {
+    minUSD: Math.round(total * 0.8),
+    maxUSD: Math.round(total * 1.2),
+    hotelUSD,
+    flightUSD
+  };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -283,8 +283,8 @@ app.get('/estimate', (req: Request, res: Response) => {
     }
     d = Math.round((e.getTime() - s.getTime()) / 86400000) + 1;
   }
-  const range = estimateCost(String(destination), t, d);
-  res.json(range);
+  const breakdown = estimateCost(String(destination), t, d);
+  res.json(breakdown);
 });
 
 app.get('/suggestions', (_req: Request, res: Response) => {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -84,7 +84,7 @@ describe('GET /estimate', () => {
       .get('/estimate')
       .query({ destination: 'Paris', days: 5, travelers: 2 });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ minUSD: 1600, maxUSD: 2400 });
+    expect(res.body).toEqual({ minUSD: 1600, maxUSD: 2400, hotelUSD: 1200, flightUSD: 800 });
   });
 
   it('accepts lengthDays alias', async () => {
@@ -92,7 +92,7 @@ describe('GET /estimate', () => {
       .get('/estimate')
       .query({ destination: 'Paris', lengthDays: 5, travelers: 2 });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ minUSD: 1600, maxUSD: 2400 });
+    expect(res.body).toEqual({ minUSD: 1600, maxUSD: 2400, hotelUSD: 1200, flightUSD: 800 });
   });
 });
 
@@ -104,6 +104,8 @@ describe('slider interactions', () => {
     const script = html.match(/<script>([\s\S]*)<\/script>/i)[1];
     class Elem {
       constructor(){ this.value=''; this.textContent=''; this.hidden=false; this.disabled=false; this.listeners={}; }
+      set innerHTML(v){ this.textContent = v; }
+      get innerHTML(){ return this.textContent; }
       addEventListener(t, cb){ (this.listeners[t] ||= []).push(cb); }
       dispatchEvent(evt){ (this.listeners[evt.type]||[]).forEach(fn=>fn(evt)); }
     }
@@ -149,7 +151,7 @@ describe('slider interactions', () => {
     global.FormData = class { constructor(){ return { entries: ()=>[] }; } };
     global.navigator = { clipboard: { writeText: async()=>{} } };
     global.Event = class { constructor(type){ this.type=type; } };
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ minUSD: 100, maxUSD: 200 }) });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ minUSD: 100, maxUSD: 200, flightUSD: 120, hotelUSD: 80 }) });
     global.fetch = fetchMock;
     eval(script);
     elements.pgDestination.value = 'Bangkok';
@@ -160,5 +162,7 @@ describe('slider interactions', () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(elements.pgEstimate.textContent).toContain('$100');
     expect(elements.pgEstimate.textContent).toContain('$200');
+    expect(elements.pgEstimate.textContent).toContain('$120');
+    expect(elements.pgEstimate.textContent).toContain('$80');
   });
 });


### PR DESCRIPTION
## Summary
- add flight and hotel breakdown to cost estimator
- forward full breakdown from `/estimate` endpoint
- show flight and hotel estimates in UI next to total range
- verify breakdown fields in API tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c027c24cd08331bc021268b7110dc0